### PR TITLE
插件文档修改：更新插件demo的下载和使用方式、动态配置插件demo示例代码更新

### DIFF
--- a/docs/zh/document/plugin/dynamic-config.md
+++ b/docs/zh/document/plugin/dynamic-config.md
@@ -37,11 +37,11 @@ dynamic.config.plugin:
 
 - 若关闭适配，即`enableCseAdapter: false`
 
-    此时插件将根据宿主应用的服务名进行订阅, 即应用配置的`spring.applicaton.name`, 插件订阅配置的group为`service=${spring.applicaton.name}`
-    
+  此时插件将根据宿主应用的服务名进行订阅, 即应用配置的`spring.applicaton.name`, 插件订阅配置的group为`service=${spring.applicaton.name}`
+
 - 若开启适配, 即`enableCseAdapter: true`
 
-    此时插件将根据**应用配置**，**服务配置**以及**自定义配置**三项数据进行配置**同时**订阅， 而这三类配置可参考`${path}/sermant-agent-x.x.x/agent/config/config.properties`, 相关配置如下：
+  此时插件将根据**应用配置**，**服务配置**以及**自定义配置**三项数据进行配置**同时**订阅， 而这三类配置可参考`${path}/sermant-agent-x.x.x/agent/config/config.properties`, 相关配置如下：
 
     ```properties
     # 服务app名称
@@ -57,10 +57,10 @@ dynamic.config.plugin:
     service.meta.customLabelValue=default
     ```
 
-    应用配置，服务配置，自定义配置说明参考[CSE配置中心概述](https://support.huaweicloud.com/devg-cse/cse_devg_0020.html)
-    - 应用配置：由`service.meta.application`与`service.meta.environment`组成， 对应的`group`为`app=default&environment=development`
-    - 服务配置：由`service.meta.application`、`service.meta.environment`以及服务名组成，此处服务即`spring.application.name`, 对应的`group`为`app=default&environment=development&service=DynamicConfigDemo`
-    - 自定义配置：由`service.meta.customLabel`与`service.meta.customLabelValue`组成， 对应的`group`为`public=default`
+  应用配置，服务配置，自定义配置说明参考[CSE配置中心概述](https://support.huaweicloud.com/devg-cse/cse_devg_0020.html)
+  - 应用配置：由`service.meta.application`与`service.meta.environment`组成， 对应的`group`为`app=default&environment=development`
+  - 服务配置：由`service.meta.application`、`service.meta.environment`以及服务名组成，此处服务即`spring.application.name`, 对应的`group`为`app=default&environment=development&service=DynamicConfigDemo`
+  - 自定义配置：由`service.meta.customLabel`与`service.meta.customLabelValue`组成， 对应的`group`为`public=default`
 
 以上为`group`的配置介绍，下面说明`content`配置，当前动态配置仅支持yaml格式, 例如配置如下内容:
 
@@ -124,22 +124,13 @@ public class ValueConfig {
 
 ### 准备工作
 
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/flowcontrol-demo/spring-cloud-demo/spring-provider) demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-dynamic-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 - [下载](https://github.com/huaweicloud/Sermant/releases) 或编译Sermant包
 - [下载](https://zookeeper.apache.org/releases#download) 并启动zookeeper
 
-### 步骤一：编译打包demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/flowcontrol-demo/spring-cloud-demo/spring-provider`目录执行以下命令：
-
-```shell
-# windows,Linux,mac
-mvn clean package
-```
-
-打包成功后，在`${path}/Sermant-examples/flowcontrol-demo/spring-cloud-demo/spring-provider/target`得到`spring-provider.jar`
-
-> **说明**： ${path}为demo应用下载所在路径。
+解压Demo二进制产物压缩包，即可得到`spring-provider.jar`。
 
 ### 步骤二：修改插件配置
 
@@ -153,9 +144,9 @@ dynamic.config.plugin:
 
 > **说明**：${path}为sermant所在路径。
 
-### 步骤三：启动demo应用
+### 步骤三：启动Demo应用
 
-参考如下命令启动demo应用
+参考如下命令启动Demo应用
 
 ```shell
 # windwos
@@ -172,10 +163,10 @@ java -javaagent:${path}/sermant-agent-x.x.x/agent/sermant-agent.jar -Dspring.app
 浏览器或curl工具访问`localhost:8003/flow`,查看控制台日志是否打印`sermant`日志
 
 
-**demo应用配置**如下：
+**Demo应用配置**如下：
 
 ```yaml
-# demo 应用配置
+# Demo 应用配置
 server:
   port: 8003
 sermant: sermant
@@ -187,28 +178,10 @@ spring:
       enabled: true
 ```
 
-**demo应用/flow接口**代码如下：
-
-```java
-// demo应用源码
-@Controller
-@ResponseBody
-@RefreshScope
-public class FlowController {
-  @Value("${sermant}")
-  private Object sermant;
-
-  @RequestMapping(value = "/flow", method = RequestMethod.GET)
-  public String flow(@RequestParam(required = false) Integer exRate, HttpServletRequest request) {
-    LOGGER.info((String) sermant);
-    return "Hello, I am zk rest template provider, my port is " + port;
-  }
-}
+当调用**flow接口**时，Demo应用将返回如下信息，此时返回sermant的值为"sermant"(该对象通过@value方式注入)：
+```text
+Hello, I am zk rest template provider, my port is 8003, sermant value is sermant
 ```
-
-当调用**flow接口**时，demo应用执行`LOGGER.info((String) sermant);`语句，在控制台打印`sermant`变量的值`sermant`，如下图所示：
-
-<MyImage src="/docs-img/dynamic-config-old-config.jpg"/>
 
 ### 步骤五：修改应用配置
 
@@ -240,6 +213,7 @@ zkCli.cmd -server localhost:2181 create /service=spring-flow-provider/config "se
 
 ### 验证
 
-再次通过浏览器或curl工具访问`localhost:8003/flow`，查看控制台是否有输出`sermant1`日志。
-
-<MyImage src="/docs-img/dynamic-config-verify.jpg"/>
+再次通过浏览器或curl工具访问`localhost:8003/flow`，Demo应用将返回如下信息，此时返回sermant的值为"sermant1"：
+```text
+Hello, I am zk rest template provider, my port is 8003, sermant value is sermant1
+```

--- a/docs/zh/document/plugin/flowcontrol.md
+++ b/docs/zh/document/plugin/flowcontrol.md
@@ -378,22 +378,13 @@ servicecomb:                            # 流量标记前缀
 
 ### 准备工作
 
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/flowcontrol-demo/spring-cloud-demo/spring-provider) demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-flowcontrol-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 - [下载](https://github.com/huaweicloud/Sermant/releases) 或编译Sermant包
 - [下载](https://zookeeper.apache.org/releases#download) 并启动zookeeper
 
-### 步骤一：编译打包demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/flowcontrol-demo/spring-cloud-demo/spring-provider`目录执行以下命令：
-
-```shell
-# windows,Linux,mac
-mvn clean package
-```
-
-打包成功后，在`${path}/Sermant-examples/flowcontrol-demo/spring-cloud-demo/spring-provider/target`得到`spring-provider.jar`。
-
-> **说明**： ${path}为demo应用下载所在路径。
+解压Demo二进制产物压缩包，即可得到`spring-provider.jar`。
 
 ### 步骤二：修改插件配置
 
@@ -408,9 +399,9 @@ flow.control.plugin:
 
 > **说明**： ${path}为sermant所在路径。
 
-### 步骤三：启动demo应用
+### 步骤三：启动Demo应用
 
-参考如下命令启动demo应用
+参考如下命令启动Demo应用
 
 ```shell
 # windwos

--- a/docs/zh/document/plugin/graceful.md
+++ b/docs/zh/document/plugin/graceful.md
@@ -211,16 +211,16 @@ spec:
 
 - 已经部署好kubernetes环境
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译sermant包
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/grace-demo/spring-grace-nacos-demo)demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/grace-demo/spring-grace-nacos-demo)Demo源码
 - [下载](https://github.com/alibaba/nacos/releases)nacos（注册中心），并部署
 
 > **注意：** 
 > 1. [动态配置中心](../user-guide/configuration-center.md)会在本场景中默认使用，由于非本场景的核心组件，因此在本文中不额外赘述。
 > 2. 容器环境需提前部署好[injector组件](../user-guide/injector.md)。
 
-### 步骤一：制作demo应用镜像
+### 步骤一：制作Demo应用镜像
 
-**1.编译打包demo应用**
+**1.编译打包Demo应用**
 
 在`${path}/Sermant-examples/grace-demo/spring-grace-nacos-demo`目录执行如下命令：
 
@@ -232,7 +232,7 @@ mvn clean package
 
 > **说明：** ${path}为demo应用下载所在路径。
 
-**2.制作demo镜像**
+**2.制作Demo镜像**
 
 修改文件夹中`${path}/Sermant-examples/grace-demo/spring-grace-nacos-demo/deploy/image`中三个服务的Dockfile（`consumerDockerfile`、`dataDockerfile`、`providerDockerfile`）中COPY操作的jar包路径，以及三个服务对应的制作镜像脚本（`build.sh`、`buildConsumer.sh`、`buildData.sh`）中version和name的值。
 

--- a/docs/zh/document/plugin/loadbalancer.md
+++ b/docs/zh/document/plugin/loadbalancer.md
@@ -82,21 +82,13 @@ rule: Random
 
 ### 准备工作
 
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/sermant-template/demo-register)demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-load-balance-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译sermant包
 - [下载](https://zookeeper.apache.org/releases.html#download)并启动zookeeper
 
-### 步骤一：编译打包demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/sermant-template/demo-register`目录执行如下命令：
-
-```shell
-mvn clean package
-```
-
-打包成功后可在`${path}/Sermant-examples/sermant-template/demo-register/resttemplate-consumer/target`得到`resttemplate-consumer.jar`包，在`${path}/Sermant-examples/sermant-template/demo-register/resttemplate-provider/target`得到`resttemplate-provider.jar`。
-
-> **说明：** ${path}为demo应用下载所在路径。
+解压Demo二进制产物压缩包，即可得到`resttemplate-consumer.jar`和`resttemplate-provider.jar`。
 
 ### 步骤二：发布流量标记
 参考使用[动态配置中心使用手册](../user-guide/configuration-center.md#发布配置)进行配置发布，发布如下配置
@@ -160,7 +152,7 @@ matches:
 zkCli.cmd -server localhost:2181 create /app=default&environment=&service=zk-rest-consumer/servicecomb.loadbalance.testLb "rule: Random"
 ```
 
-### 步骤四：启动demo应用
+### 步骤四：启动Demo应用
 
 参考如下命令启动两个生产者
 

--- a/docs/zh/document/plugin/monitor.md
+++ b/docs/zh/document/plugin/monitor.md
@@ -117,20 +117,15 @@ monitor.config:                       # 监控插件配置。
 
 ### 准备工作
 
-- [下载](https://start.spring.io/#!type=maven-project&language=java&platformVersion=2.7.7&packaging=jar&jvmVersion=1.8&groupId=com.example&artifactId=demo&name=demo&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.demo&dependencies=web)demo应用
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-monitor-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译sermant包
 - [下载](https://github.com/prometheus/prometheus/releases)Prometheus
 
 > 注意：[动态配置中心](../user-guide/configuration-center.md)会在本场景中默认使用，由于非本场景的核心组件，因此在本文中不额外赘述。
 
-### 步骤一：编译打包demo应用
-在demo应用的根目录执行如下命令对demo应用进行打包:
+### 步骤一：获取Demo二进制产物
 
-```shell
-mvn clean package
-```
-打包成功后，在demo根目录会生成`target`文件夹,进入`target`文件夹可以得到demo-0.0.1-SNAPSHOT.jar包。
-
+解压Demo二进制产物压缩包，即可得到`monitor-demo.jar`。
 
 ### 步骤二：修改配置
 
@@ -163,16 +158,16 @@ scrape_configs:
 
 ### 步骤三：启动应用
 
-- 参考如下命令启动demo应用
+- 参考如下命令启动Demo应用
 
 ```shell
 # Run under Linux
-java -javaagent:${path}/sermant-agent-x.x.x/agent/sermant-agent.jar=appName=default -jar demo-0.0.1-SNAPSHOT.jar
+java -javaagent:${path}/sermant-agent-x.x.x/agent/sermant-agent.jar=appName=default -jar monitor-demo.jar
 ```
 
 ```shell
 # Run under Windows
-java -javaagent:${path}\sermant-agent-x.x.x\agent\sermant-agent.jar=appName=default -jar demo-0.0.1-SNAPSHOT.jar
+java -javaagent:${path}\sermant-agent-x.x.x\agent\sermant-agent.jar=appName=default -jar monitor-demo.jar
 ```
 
 > **说明：** ${path}为sermant实际安装路径，x.x.x代表sermant某个版本号。

--- a/docs/zh/document/plugin/register-migration.md
+++ b/docs/zh/document/plugin/register-migration.md
@@ -194,27 +194,16 @@ dubbo:
 
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译sermant包
   
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/registry-demo/dubbo-registry-demo)dubbo-registry-demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-registry-demo-1.2.1.tar.gz)
+  Demo二进制产物压缩包
 
 - [下载](https://github.com/apache/servicecomb-service-center)ServiceComb，并启动
 
 > **注意：** [动态配置中心](../user-guide/configuration-center.md)会在本场景中默认使用，由于非本场景的核心组件，因此在本文中不额外赘述。
 
-#### 步骤一：编译打包dubbo-registry-demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/registry-demo/dubbo-registry-demo`目录执行如下命令：
-
-```shell
-# windows
-mvn clean package
-
-# mac, linux
-mvn clean package
-```
-
-打包成功后可在`${path}/Sermant-examples/registry-demo/dubbo-registry-demo/dubbo-registry-consumer/target`得到` dubbo-registry-consumer.jar`包，在`${path}/Sermant-examples/registry-demo/dubbo-registry-demo/dubbo-registry-provider/target`得到`dubbo-registry-provider`包。
-
-> **说明：** ${path}为dubbo-registry-demo应用下载所在路径。
+解压Demo二进制产物压缩包，即可得到`dubbo-registry-consumer.jar`和`dubbo-registry-provider.jar`。
 
 #### 步骤二：部署应用
 
@@ -238,7 +227,7 @@ java -Dservicecomb.service.enableDubboRegister=true -javaagent:${path}\sermant-a
 java -Dservicecomb.service.enableDubboRegister=true -javaagent:${path}/sermant-agent-x.x.x/agent/sermant-agent.jar=appName=default -jar dubbo-registry-provider.jar
 ```
 
-> **说明：** 其中${path}需要替换为sermant包路径，x.x.x需要替换为sermant实际版本号，appName为agent启动参数中的应用名，与注册参数无关，执行命令的目录需要为demo应用的jar包目录。
+> **说明：** 其中${path}需要替换为sermant包路径，x.x.x需要替换为sermant实际版本号，appName为agent启动参数中的应用名，与注册参数无关，执行命令的目录需要为Demo应用的jar包目录。
 
 > **注意：** 为了便于测试，这里使用了-Dservicecomb.service.enableDubboRegister=true的方式打开了dubbo注册开关，如果使用了其它的[参数配置方式](../user-guide/sermant-agent.md#参数配置方式)打开了dubbo注册开关，则无需添加该参数。
 
@@ -261,7 +250,7 @@ java -Dservicecomb.service.enableDubboRegister=true -javaagent:${path}/sermant-a
 
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译sermant包
 
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/registry-demo/spring-cloud-registry-demo)spring-cloud-registry-demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-registry-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 
 - [下载](https://github.com/apache/servicecomb-service-center)ServiceComb，并启动
 
@@ -269,33 +258,16 @@ java -Dservicecomb.service.enableDubboRegister=true -javaagent:${path}/sermant-a
 
 > **注意：** [动态配置中心](../user-guide/configuration-center.md)会在本场景中默认使用，由于非本场景的核心组件，因此在本文中不额外赘述。
 
-#### 步骤一：编译打包spring-cloud-registry-demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/registry-demo/spring-cloud-registry-demo`目录执行如下命令：
-
-```shell
-# windows
-mvn clean package
-
-# mac, linux
-mvn clean package
-```
-
-打包成功后可在`${path}/Sermant-examples/registry-demo/spring-cloud-registry-demo/spring-cloud-registry-consumer/target`得到` spring-cloud-registry-consumer.jar`包，在`${path}/Sermant-examples/registry-demo/spring-cloud-registry-demo/spring-cloud-registry-provider/target`得到`spring-cloud-registry-provider.jar`包。
-
-> **说明：** ${path}为spring-cloud-registry-demo应用下载所在路径。
+解压Demo二进制产物压缩包，即可得到`spring-cloud-registry-consumer.jar`和`spring-cloud-registry-provider.jar`。
 
 #### 步骤二：部署应用
 
 （1）启动原生产者与原消费者（注册到Zookeeper中）
 
 ```shell
-# windows
-java -jar spring-cloud-registry-provider.jar
-
-java -jar spring-cloud-registry-consumer.jar
-
-# mac, linux
+# windows, linux, mac
 java -jar spring-cloud-registry-provider.jar
 
 java -jar spring-cloud-registry-consumer.jar

--- a/docs/zh/document/plugin/removal.md
+++ b/docs/zh/document/plugin/removal.md
@@ -72,27 +72,15 @@ rules:                  # 离群实例摘除规则，key：服务名称（为def
 
 ### 准备工作
 
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/removal-demo) removal-demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-removal-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 - [下载](https://github.com/huaweicloud/Sermant/releases) 或编译Sermant包
 - [下载](https://zookeeper.apache.org/releases#download) 并启动zookeeper
 
 > **注意：** [动态配置中心](../user-guide/configuration-center.md)会在本场景中默认使用，由于非本场景的核心组件，因此在本文中不额外赘述。
 
-### 步骤一：编译打包demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/removal-demo`目录执行以下命令：
-
-```shell
-# windows,Linux,mac
-mvn clean package
-```
-
-打包成功后：
-  在`${path}/Sermant-examples/removal-demo/rest-consumer/target`得到`rest-consumer-1.0.0.jar`。
-  在`${path}/Sermant-examples/removal-demo/rest-provider/target`得到`rest-provider-1.0.0.jar`。
-
-> **说明**： ${path}为demo应用下载所在路径。
-
+解压Demo二进制产物压缩包，即可得到`rest-consumer.jar`和`rest-provider.jar`。
 
 ### 步骤二：修改配置
 
@@ -114,31 +102,31 @@ removal.config:
 
 ### 步骤三：启动应用
 
-- 参考如下命令启动demo应用
+- 参考如下命令启动Demo应用
 
 （1）启动消费者
 
 ```shell
 # Run under Linux
-java -javaagent:${path}/sermant-agent-x.x.x/agent/sermant-agent.jar=appName=default -Dniws.loadbalancer.availabilityFilteringRule.filterCircuitTripped=false -jar rest-consumer-1.0.0.jar
+java -javaagent:${path}/sermant-agent-x.x.x/agent/sermant-agent.jar=appName=default -Dniws.loadbalancer.availabilityFilteringRule.filterCircuitTripped=false -jar rest-consumer.jar
 ```
 
 ```shell
 # Run under Windows
-java -javaagent:${path}\sermant-agent-x.x.x\agent\sermant-agent.jar=appName=default -Dniws.loadbalancer.availabilityFilteringRule.filterCircuitTripped=false -jar rest-consumer-1.0.0.jar
+java -javaagent:${path}\sermant-agent-x.x.x\agent\sermant-agent.jar=appName=default -Dniws.loadbalancer.availabilityFilteringRule.filterCircuitTripped=false -jar rest-consumer.jar
 ```
 
 （2）启动生产者
 ```shell
 # windows,Linux,mac
-java -jar rest-provider-1.0.0.jar
+java -jar rest-provider.jar
 ```
 
 （3）启动第二个生产者
 
 ```shell
 # windows,Linux,mac
-java -Dtimeout=2000 -Dserver.port=8006 -jar rest-provider-1.0.0.jar
+java -Dtimeout=2000 -Dserver.port=8006 -jar rest-provider.jar
 ```
 
 

--- a/docs/zh/document/plugin/router.md
+++ b/docs/zh/document/plugin/router.md
@@ -292,27 +292,15 @@
 
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译sermant包
   
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/router-demo/spring-cloud-router-demo)spring-cloud-router-demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-router-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 
 - [下载](https://github.com/apache/servicecomb-service-center)ServiceComb（注册中心），并启动
 
 - [下载](https://zookeeper.apache.org/releases.html#download)Zookeeper（动态配置中心），并启动
 
-### 步骤一：编译打包spring-cloud-router-demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/router-demo/spring-cloud-router-demo`目录执行如下命令：
-
-```shell
-# windows
-mvn clean package
-
-# mac, linux
-mvn clean package
-```
-
-打包成功后可在`${path}/Sermant-examples/router-demo/spring-cloud-router-demo/spring-cloud-router-consumer/target`得到` spring-cloud-router-consumer.jar`包，在`${path}/Sermant-examples/router-demo/spring-cloud-router-demo/spring-cloud-router-provider/target`得到`spring-cloud-router-provider`包，在`${path}/Sermant-examples/router-demo/spring-cloud-router-demo/spring-cloud-router-zuul/target`得到`spring-cloud-router-zuul`包。
-
-> 说明：${path}为spring-cloud-router-demo应用下载所在路径。
+解压Demo二进制产物压缩包，即可得到`spring-cloud-router-consumer.jar`、`spring-cloud-router-provider.jar`和`spring-cloud-router-zuul.jar`。
 
 ### 步骤二：部署应用
 

--- a/docs/zh/document/plugin/springboot-registry.md
+++ b/docs/zh/document/plugin/springboot-registry.md
@@ -98,25 +98,13 @@ value: service-b,service-c # 白名单服务集合，仅当strategy配置为whit
 
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译sermant包
 
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/registry-demo/springboot-registry-demo)springboot-registry-demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-springboot-registry-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 
 - [下载](https://zookeeper.apache.org/releases.html#download)Zookeeper（动态配置中心&注册中心），并启动
 
-### 步骤一：编译打包springboot-registry-demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/registry-demo/springboot-registry-demo`目录执行如下命令：
-
-```shell
-# windows
-mvn clean package
-
-# mac, linux
-mvn clean package
-```
-
-打包成功后可在`${path}/Sermant-examples/registry-demo/springboot-registry-demo/service-a/target`得到` service-a.jar`包，在`${path}/Sermant-examples/registry-demo/springboot-registry-demo/service-b/target`得到`service-b.jar`包。
-
-> **说明：** path为springboot-registry-demo应用下载所在路径。
+解压Demo二进制产物压缩包，即可得到`service-a.jar`和`service-b.jar`。
 
 ### 步骤二：部署应用
 

--- a/docs/zh/document/plugin/tag-transmission.md
+++ b/docs/zh/document/plugin/tag-transmission.md
@@ -86,20 +86,11 @@ x-sermant-version: v1          // 自定义header，此处表示通过流量染�
 ### 准备工作
 
 - [下载 ](https://github.com/huaweicloud/Sermant/releases/download/v1.2.0/sermant-1.2.0.tar.gz)Sermant Release包
-- [下载](https://github.com/huaweicloud/Sermant-examples/tree/main/tag-transmission-demo) tag-transmission-demo源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-tag-transmission-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 
-### 步骤一：编译打包tag-transmission-demo应用
+### 步骤一：获取Demo二进制产物
 
-在`${path}/Sermant-examples/tag-transmission-demo`目录执行如下命令：
-
-```shell
-# windows, mac, linux
-mvn clean package
-```
-
-打包成功后可在`${path}/Sermant-examples/tag-transmission-demo/http-client-demo/target`得到` http-client-demo.jar`包，在`${path}/Sermant-examples/tag-transmission-demo/http-server-demo/target`得到`http-server-demo.jar`包，
-
-> 说明：此处${path}为Sermant-examples文件夹所在路径。
+解压Demo二进制产物压缩包，即可得到`http-client-demo.jar`和`http-server-demo.jar`。
 
 ### 步骤二：部署应用
 

--- a/docs/zh/document/plugin/visibility.md
+++ b/docs/zh/document/plugin/visibility.md
@@ -49,11 +49,15 @@ visibility.config:
 ### 准备工作
 
 - [下载](https://github.com/huaweicloud/Sermant/releases)/编译Sermant包
-- [下载](https://github.com/huaweicloud/Sermant/tree/develop/sermant-integration-tests/dubbo-test)dubbo-test源码
+- [下载](https://github.com/huaweicloud/Sermant-examples/releases/download/v1.2.1/sermant-examples-visibility-demo-1.2.1.tar.gz) Demo二进制产物压缩包
 
 > 注意：[动态配置中心](../user-guide/configuration-center.md)会在本场景中默认使用，由于非本场景的核心组件，因此在本文中不额外赘述。
 
-### 步骤一：修改配置
+### 步骤一：获取Demo二进制产物
+
+解压Demo二进制产物压缩包，即可得到`dubbo-integration-consumer.jar`和`dubbo-integration-provider.jar`。
+
+### 步骤二：修改配置
 
 - 修改Sermant-agent配置
 在`${path}/sermant-agent-x.x.x/agent/config/config.properties`找到该配置文件，修改的配置项如下所示：
@@ -68,16 +72,6 @@ agent.service.visibility.enable=true # 控制服务可见性能力的开关
 visibility.config:
   startFlag: true        # 服务可见性采集开关。为true时进行数据采集上报。
 ```
-
-### 步骤二：编译打包dubbo-test应用
-
-执行如下命令，对dubbo-test项目中的子项目dubbo-2-6-integration-consumer和dubbo-2-6-integration-provider进行打包:
-
-```shell
-mvn clean package
-```
-
-可在dubbo-2-6-integration-consumer项目中的`target`文件夹中得到dubbo-integration-consumer.jar包和dubbo-2-6-integration-provider项目中得到dubbo-integration-provider.jar包。
 
 ### 步骤三：启动应用
 


### PR DESCRIPTION
【修复issue】#229

【修改内容】
1. 修改了动态配置插件中demo使用和描述
2. 修改了插件介绍章节，增加了对demo多种下载方式的描述
3. 修改了插件的操作和结果验证中的demo使用方式，改为二进制（除无损上下线，因需要镜像方式启动）